### PR TITLE
Add purpose and practice documentation for CDO Shape repositories

### DIFF
--- a/ontology/development/index.md
+++ b/ontology/development/index.md
@@ -56,7 +56,7 @@ Part of the testing process for the ontology is assessing impact of proposals, a
 * [https://caseontology.org/ontology/CASE-develop.ttl](https://caseontology.org/ontology/CASE-develop.ttl)
 * [https://caseontology.org/ontology/CASE-unstable.ttl](https://caseontology.org/ontology/CASE-unstable.ttl)
 
-These are monolithic and syntax-normalized builds of the CASE and UCO ontologies.  Their states are used to review each of the CASE examples, and their validation SHACL results are stored as files alongside the examples' source materials.  For instance, here are the current validation results for the [website's Asgard example](https://caseontology.org/examples/asgard/):
+These are monolithic and syntax-normalized builds of the CASE and UCO ontologies.  Their states are used to review each of the CASE examples, and their validation [SHACL](https://www.w3.org/TR/shacl/) results are stored as files alongside the examples' source materials.  For instance, here are the current validation results for the [website's Asgard example](https://caseontology.org/examples/asgard/):
 
 * [Versus the current release](https://github.com/casework/casework.github.io/blob/master/examples/asgard/asgard_validation.ttl)
 * [Versus the develop state](https://github.com/casework/casework.github.io/blob/master/examples/asgard/asgard_validation-develop.ttl)
@@ -115,3 +115,53 @@ Each "Profile" repository follows this pattern:
 These repositories can be brought together to review how well current examples adhere to the profiles' ontological alignments, whether by confirming graph-individuals' disjointedness through RDFS expansion, or through a consistency review through OWL-DL expansion.  (A Github repository attempting this is currently under development.)  Bringing these profiles together is one reason the CDO class is a subclass of the external class, rather than an equivalent class.  One of the objectives is to explore whether multiple profiles reveal an inconsistency in unrelated ontologies, when exercised in a CDO example.  (The other reason equivalent-class designations are avoided is to avoid inappropriate scope-expansions of CDO rules within adopters' knowledge graphs, such as individuals under UCO hierarchies generally being [urged to end with UUIDs](https://github.com/ucoProject/UCO/blob/1.0.0/ontology/uco/core/core.ttl#L429).)
 
 These repositories are each designated as "Exploratory".  Their contents are neither official, versioned beyond Git commit mechanisms, nor subject to Ontology Committee workflows for revisions.  They are expected to change as modeling needs are demonstrated through new class, property, and example development.  Those wishing to adopt a Profile are encouraged to do so using a Git submodule.  Contributions or requests for alignment explorations are welcome.
+
+
+<a id="shapes" style="padding-top: 5em;"></a>
+# Shapes
+*([Link](#shapes))*
+
+Among the objectives within CDO repositories are interchange, and semantic interoperability, of data.  One of the steps in establishing semantic interoperability is having clear syntactic rules of usage of various ontologies' predicates.
+
+Within CDO, ontologies make extensive use of [SHACL](https://www.w3.org/TR/shacl/) to simultaneously define concepts and their requirements of usage within graphs.  Many other ontologies exist based on [OWL](https://www.w3.org/TR/2012/REC-owl2-primer-20121211/), which provides a language for knowledge expansion, but fewer mechanisms than SHACL for data validation.  Some invalid data can be recognized with OWL, such as declaring an individual to be a member of two disjoint classes (which translates to a logical inconsistency that the Empty Set has something in it).  But certain requirements can't be tested with OWL due to its "Open world" model, such as minimal cardinality of a property unrelated to other classes or properties: if an individual is specified by OWL to have a certain property used exactly once (such as a `ex:Screw` having exactly one integer `ex:threadCount` value), and the graph doesn't have it, OWL assumes the value exists, but just isn't specified.  SHACL considers this a data error.  OWL doesn't consider 0 distinct specified values a data error, but does consider 2 distinct values to be a data error.
+
+Other ontologies encoded in OWL often provide exploration and coverage of concepts that are not in the scope of CDO outside of specific applications, or that might be close enough to fulfilling a CDO core need that the ontology is considered for adoption by one of the CDO ontologies.  CDO applications wishing to use that external ontology often still have a desire or requirement to provide data validation capabilities, which might not be directly available if the external ontology does not provide a "closed world" rule set.  Worse, if there is an error in the OWL syntax provided by the external ontology---even one inconsequential to most of the model---OWL ontology validators have the potential to fixate on that error and possibly obscure errors that are more directly relevant to end users among their knowledge graphs' nodes.
+
+To bridge potential understanding gaps, and to better understand external ontologies, CDO provides SHACL shapes for external ontologies when they fit some need anywhere within the CDO ecosystem.  SHACL shapes are provided as a set of repositories on GitHub, each scoped to a particular external ontology.  Because SHACL can provide validation rules for any RDF, the shapes are not necessarily limited to OWL ontologies - shapes are provided for the OWL language itself, having been started for [UCO Issue 406](https://github.com/ucoProject/UCO/issues/406); and some shapes have been explored for non-OWL RDF schemata, having been started in [CASE-Corpora](https://github.com/casework/CASE-Corpora/tree/main/shapes).
+
+The shape repositories can be found on GitHub or on the [CDO Project Release Flow](https://cyberdomainontology.org/resources/project_release_flow.html) diagram, searching for "`-Shapes-`".
+
+The shape repositories follow these practices:
+
+* Each repository is conceptually scoped to one RDF-based data model.
+* The RDF Schema or OWL Ontology that is the repository's focus is version-controlled in a form normalized like other CDO ontologies, under the repository's `/dependencies` directory.
+   - The method of how the file came to be there is also version-controlled, and will typically be by reformatting a file from a Git submodule, or by downloading from its ontology-serving IRI.
+   - The reasons for tracking a copy of the file include, but are not limited to:
+      * Reducing the syntaxes needed for CDO users (CDO's graphs are managed in Turtle and JSON-LD);
+      * "Pinning" an external ontology version throughout CDO;
+      * Addressing issues with intermittent resource unavailability due to networked resource outage;
+      * Addressing syntax issues in either the concrete serialization language or OWL concept usage, which if not addressed prevent consumption of the ontology in OWL-focused tooling.  When these occur, a new `owl:versionIRI` specialized to the CDO shapes repository is inlined, with a note that the file is different from its authoriative version, is non-authoritative, and is being provided with this IRI only until the fix is addressed by the authoritative versions' maintainers.
+* The shapes graph is reviewed with unit test processes, and exercised in Continuous Integration against a graph of exemplar individuals.
+* The shapes repository will follow either ["Continuous-release" branching](#branching-cdo-continuous) or ["Git-flow" branching](#branching-cdo-git-flow) as described in this document, according to its known usages and/or any received requests.
+   - If the shapes repository follows "Git-flow" branching, [SEMVER versioning](https://semver.org/) is used.  Decisions on release schedules for SEMVER-major releases will allow for feedback from known adopters.
+      * For example, the shapes repository specific to reviewing OWL ontology syntax will have SEMVER-major releases decided by the UCO Ontology Committee, due to its [original implementation](https://github.com/ucoProject/UCO/issues/406) having been part of UCO 1.0.0.
+   - If the shapes repository follows "Continuous-release" branching, users are encouraged to track the repository with a Git submodule and encode some kind of referential-freshness review mechanism, such as in the scheduled `check-supply-chain-submodules` target in [CASE-Corpora's root Makefile](https://github.com/casework/CASE-Corpora/blob/main/Makefile).
+
+The shape graphs follow the below practices.
+
+* The external ontology is imported with `owl:imports`.
+   - This is to catch when a knowledge base imports two potentially conflicting versions of the same ontology, using OWL's import rules (referring to OWL 2 Syntax sections [3.1](https://www.w3.org/TR/owl2-syntax/#Ontology_IRI_and_Version_IRI) and [3.3](https://www.w3.org/TR/owl2-syntax/#Versioning_of_OWL_2_Ontologies)).
+* OWL property domains and ranges using `rdfs:domain` and `rdfs:range` are turned into SHACL constraints that raise `sh:Violation`-severity validation results when not satisfied by input graphs.
+   - For applications that perform OWL and/or RDFS expansion of input graphs before running SHACL validation, this should mean the domain and range statements should not raise a SHACL violation.
+   - RDF property domain and range specifications are adpated the same as OWL properties, when using `rdfs:domain` and `rdfs:range`.
+   - RDF property domain-like and range-like specifications (those using something like `domainIncludes` and `rangeIncludes`) are adapted like OWL properties, except they will raise `sh:Info`-severity validation results.  This is because expansion (/inference) semantics are not currently known to be defined outside of usage of `rdfs:domain` and `rdfs:range`, so a gentler notice is given instead to encourage review of whether the flagged graph-individuals should carry the suggested type assertion.
+* Shape graphs are not known to be compatible, and make no claims of compatibility, with usage of `owl:sameAs`.
+* `owl:FunctionalProperty`s and `owl:InverseFunctionalProperty`s are turned into class-independent SHACL maximum-count-one constraints.
+* `owl:Restriction`s using `owl:allValuesFrom` are turned into class-specific SHACL constraints.
+* `owl:Restriction`s using `owl:maxCardinality` or `owl:maxQualifiedCardinality` are turned into class-specific SHACL maximum-count constraints.
+* `owl:Restriction`s using `owl:someValuesFrom`, `owl:minCardinality`, or `owl:minQualifiedCardinality` are ignored.
+   - While OWL's open world assumption allows for a node to be expected to exist, raising a SHACL result when one is not found is likely to be more harm than help.  To quell that result, a node would need to be invented, and there are too-possible scenarios where that would not be appropriate because one might be found later in a workflow, and would then need to be de-conflicted with the invented node.  (This also pertains to the shapes graphs not attempting compatibility with `owl:sameAs`.)  For `owl:DatatypeProperty`s, this is further stymied by OWL lacking an explicit "Null" or "Not yet known" literal-value that could be used as a stand-in value.
+
+At this time, no programmatic support is provided to convert an OWL ontology into a SHACL graph.  Some procedures are known to be algorithmically specifiable---for instance, most of the above list is likely scriptable.  However, at least one community member's experience has found defining SHACL shapes to be a beneficial exercise in actively reading ontologies, as well as finding challenges in defining rules pertaining to some OWL constructs.
+
+Last, the shape graphs have a goal of not needing to be provided by CDO.  Data validation is a significant, general need in workflows.  Those best suited to provide validation rulesets for an ontology are the maintainers of that ontology.  Should a non-CDO ontology maintainer become interested in adopting and incorporating a CDO shapes graph and/or test suite into their software, CDO welcomes this opportunity for exchange and transfer of knowledge.

--- a/ontology/development/index.md
+++ b/ontology/development/index.md
@@ -131,6 +131,9 @@ To bridge potential understanding gaps, and to better understand external ontolo
 
 The shape repositories can be found on GitHub or on the [CDO Project Release Flow](https://cyberdomainontology.org/resources/project_release_flow.html) diagram, searching for "`-Shapes-`".
 
+
+## Practices
+
 The shape repositories follow these practices:
 
 * Each repository is conceptually scoped to one RDF-based data model.
@@ -161,6 +164,9 @@ The shape graphs follow the below practices.
 * `owl:Restriction`s using `owl:maxCardinality` or `owl:maxQualifiedCardinality` are turned into class-specific SHACL maximum-count constraints.
 * `owl:Restriction`s using `owl:someValuesFrom`, `owl:minCardinality`, or `owl:minQualifiedCardinality` are ignored.
    - While OWL's open world assumption allows for a node to be expected to exist, raising a SHACL result when one is not found is likely to be more harm than help.  To quell that result, a node would need to be invented, and there are too-possible scenarios where that would not be appropriate because one might be found later in a workflow, and would then need to be de-conflicted with the invented node.  (This also pertains to the shapes graphs not attempting compatibility with `owl:sameAs`.)  For `owl:DatatypeProperty`s, this is further stymied by OWL lacking an explicit "Null" or "Not yet known" literal-value that could be used as a stand-in value.
+
+
+## Notes
 
 At this time, no programmatic support is provided to convert an OWL ontology into a SHACL graph.  Some procedures are known to be algorithmically specifiable---for instance, most of the above list is likely scriptable.  However, at least one community member's experience has found defining SHACL shapes to be a beneficial exercise in actively reading ontologies, as well as finding challenges in defining rules pertaining to some OWL constructs.
 


### PR DESCRIPTION
For review purposes, it might be helpful to see how the shapes graphs in [this CASE-Corpora directory](https://github.com/casework/CASE-Corpora/tree/d702888284c82de48415e16d87f93b60a91957a7/shapes), or the [UCO-Profile-BFO shapes graph](https://github.com/ucoProject/UCO-Profile-BFO/blob/069a2ba260000e28fe79e782e50fc00f8bf9dd81/shapes/sh-bfo.ttl), align with this documentation.